### PR TITLE
Use error propagation

### DIFF
--- a/benches/compute_dag_bench.rs
+++ b/benches/compute_dag_bench.rs
@@ -24,7 +24,7 @@ fn compute_dag(tasks: Vec<DefaultTask>) {
     env.set("base", 2usize);
     dag.set_env(env);
 
-    assert!(dag.start().unwrap());
+    assert!(dag.start().is_ok());
     // Get execution result.
     let _res = dag.get_result::<usize>().unwrap();
 }

--- a/examples/compute_dag.rs
+++ b/examples/compute_dag.rs
@@ -83,7 +83,7 @@ fn main() {
     env.set("base", 2usize);
     dag.set_env(env);
     // Start executing this dag
-    assert!(dag.start().unwrap());
+    assert!(dag.start().is_ok());
     // Get execution result.
     let res = dag.get_result::<usize>().unwrap();
     println!("The result is {}.", res);

--- a/examples/custom_log.rs
+++ b/examples/custom_log.rs
@@ -14,5 +14,5 @@ fn main() {
     let _ = SimpleLogger::init(LevelFilter::Info, Config::default());
 
     let mut dag = Dag::with_yaml("tests/config/correct.yaml", HashMap::new()).unwrap();
-    assert!(dag.start().unwrap());
+    assert!(dag.start().is_ok());
 }

--- a/examples/engine.rs
+++ b/examples/engine.rs
@@ -76,7 +76,7 @@ fn main() {
     // Add dag3 to engine.
     engine.append_dag("graph3", dag3);
     // Execute dag in order, the order should be dag1, dag2, dag3.
-    assert_eq!(engine.run_sequential(), vec![true, true, true]);
+    assert!(engine.run_sequential().is_ok());
     // Get the execution results of dag1 and dag2.
     assert_eq!(
         engine.get_dag_result::<usize>("graph1").unwrap().as_ref(),

--- a/examples/yaml_dag.rs
+++ b/examples/yaml_dag.rs
@@ -10,11 +10,11 @@ use std::collections::HashMap;
 fn main() {
     env_logger::init();
     let mut job = Dag::with_yaml("tests/config/correct.yaml", HashMap::new()).unwrap();
-    assert!(job.start().unwrap());
+    assert!(job.start().is_ok());
 
     let content = load_file("tests/config/correct.yaml").unwrap();
     let mut job = Dag::with_yaml_str(&content, HashMap::new()).unwrap();
-    assert!(job.start().unwrap());
+    assert!(job.start().is_ok());
     let out = job.get_results::<Content>();
     for (k, v) in out {
         println!("{k} {:#?}", v.unwrap().get::<(Vec<String>, Vec<String>)>());

--- a/src/bin/dagrs.rs
+++ b/src/bin/dagrs.rs
@@ -24,7 +24,7 @@ fn main() {
 
     let yaml_path = args.yaml;
     let mut dag = Dag::with_yaml(yaml_path.as_str(), HashMap::new()).unwrap();
-    assert!(dag.start().unwrap());
+    assert!(dag.start().is_ok());
 }
 
 fn init_logger(args: &Args) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ pub use engine::{Dag, DagError, Engine};
 pub use task::{
     alloc_id, Action, CommandAction, Complex, DefaultTask, Input, Output, Simple, Task,
 };
-pub use utils::{EnvVar, ParseError, Parser};
+pub use utils::{EnvVar, Parser};
 #[cfg(feature = "yaml")]
 pub use yaml::{FileContentError, FileNotFound, YamlParser, YamlTask, YamlTaskError};
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -8,4 +8,4 @@ pub mod file;
 mod parser;
 
 pub use self::env::EnvVar;
-pub use self::parser::{ParseError, Parser};
+pub use self::parser::Parser;

--- a/src/utils/parser.rs
+++ b/src/utils/parser.rs
@@ -1,7 +1,6 @@
 //! Task configuration file parser interface
-use thiserror::Error;
 
-use crate::{task::Task, Action};
+use crate::{task::Task, Action, DagError};
 use std::collections::HashMap;
 
 /// Generic parser traits. If users want to customize the configuration file parser, they must implement this trait.
@@ -24,31 +23,11 @@ pub trait Parser {
         &self,
         file: &str,
         specific_actions: HashMap<String, Action>,
-    ) -> Result<Vec<Box<dyn Task>>, ParseError>;
+    ) -> Result<Vec<Box<dyn Task>>, DagError>;
 
     fn parse_tasks_from_str(
         &self,
         content: &str,
         specific_actions: HashMap<String, Action>,
-    ) -> Result<Vec<Box<dyn Task>>, ParseError>;
-}
-
-/// Errors that may occur during configuration file parsing.
-/// This structure stores error information. Users need to customize error types and implement conversion
-/// from custom error types to [`ParseError`].
-/// By default, a conversion from `String` type to [`ParseError`] is provided.
-#[derive(Debug, Error)]
-#[error("{0}")]
-pub struct ParseError(pub String);
-
-impl From<String> for ParseError {
-    fn from(value: String) -> Self {
-        ParseError(value)
-    }
-}
-
-impl From<std::io::Error> for ParseError {
-    fn from(value: std::io::Error) -> Self {
-        ParseError(value.to_string())
-    }
+    ) -> Result<Vec<Box<dyn Task>>, DagError>;
 }

--- a/src/yaml/mod.rs
+++ b/src/yaml/mod.rs
@@ -55,12 +55,11 @@
 mod yaml_parser;
 mod yaml_task;
 
+use crate::DagError;
 use thiserror::Error;
 
 pub use self::yaml_parser::YamlParser;
 pub use self::yaml_task::YamlTask;
-
-use crate::ParseError;
 
 /// Errors about task configuration items.
 #[derive(Debug, Error)]
@@ -95,20 +94,20 @@ pub enum FileContentError {
 #[error("File not found. [{0}]")]
 pub struct FileNotFound(pub std::io::Error);
 
-impl From<YamlTaskError> for ParseError {
+impl From<YamlTaskError> for DagError {
     fn from(value: YamlTaskError) -> Self {
-        value.to_string().into()
+        DagError::ParserError(value.to_string())
     }
 }
 
-impl From<FileContentError> for ParseError {
+impl From<FileContentError> for DagError {
     fn from(value: FileContentError) -> Self {
-        value.to_string().into()
+        DagError::ParserError(value.to_string())
     }
 }
 
-impl From<FileNotFound> for ParseError {
+impl From<FileNotFound> for DagError {
     fn from(value: FileNotFound) -> Self {
-        value.to_string().into()
+        DagError::ParserError(value.to_string().into())
     }
 }

--- a/tests/dag_job_test.rs
+++ b/tests/dag_job_test.rs
@@ -7,7 +7,7 @@ use dagrs::{Complex, Dag, DagError, DefaultTask, EnvVar, Input, Output};
 #[test]
 fn yaml_task_correct_execute() {
     let mut job = Dag::with_yaml("tests/config/correct.yaml", HashMap::new()).unwrap();
-    assert!(job.start().unwrap());
+    assert!(job.start().is_ok());
 }
 
 #[test]
@@ -31,7 +31,7 @@ fn yaml_task_failed_execute() {
     let res = Dag::with_yaml("tests/config/script_run_failed.yaml", HashMap::new())
         .unwrap()
         .start();
-    assert!(!res.unwrap());
+    assert!(!res.is_ok());
 }
 
 #[test]
@@ -128,7 +128,7 @@ fn test_dag(keep_going: bool, num_some_output: Option<usize>) {
     }
 
     job.set_env(env);
-    assert!(!job.start().unwrap()); // reports a failure
+    assert!(!job.start().is_ok()); // reports a failure
 
     // but the results for independent tasks are still available
     let output = job.get_results::<usize>();

--- a/tests/yaml_parser_test.rs
+++ b/tests/yaml_parser_test.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 
-use dagrs::{ParseError, Parser, Task, YamlParser};
+use dagrs::{DagError, Parser, Task, YamlParser};
 
 #[test]
 fn file_not_found_test() {
-    let no_such_file: Result<Vec<Box<dyn Task>>, ParseError> =
+    let no_such_file: Result<Vec<Box<dyn Task>>, DagError> =
         YamlParser.parse_tasks("./no_such_file.yaml", HashMap::new());
     // let err = no_such_file.unwrap_err().to_string();
     // println!("{err}");
@@ -13,7 +13,7 @@ fn file_not_found_test() {
 
 #[test]
 fn illegal_yaml_content() {
-    let illegal_content: Result<Vec<Box<dyn Task>>, ParseError> =
+    let illegal_content: Result<Vec<Box<dyn Task>>, DagError> =
         YamlParser.parse_tasks("tests/config/illegal_content.yaml", HashMap::new());
     // let err = illegal_content.unwrap_err().to_string();
     // println!("{err}");
@@ -22,7 +22,7 @@ fn illegal_yaml_content() {
 
 #[test]
 fn empty_content() {
-    let empty_content: Result<Vec<Box<dyn Task>>, ParseError> =
+    let empty_content: Result<Vec<Box<dyn Task>>, DagError> =
         YamlParser.parse_tasks("tests/config/empty_file.yaml", HashMap::new());
     // let err = empty_content.unwrap_err().to_string();
     // println!("{err}");
@@ -31,7 +31,7 @@ fn empty_content() {
 
 #[test]
 fn yaml_no_start_with_dagrs() {
-    let forget_dagrs: Result<Vec<Box<dyn Task>>, ParseError> =
+    let forget_dagrs: Result<Vec<Box<dyn Task>>, DagError> =
         YamlParser.parse_tasks("tests/config/no_start_with_dagrs.yaml", HashMap::new());
     // let err = forget_dagrs.unwrap_err().to_string();
     // println!("{err}");
@@ -40,7 +40,7 @@ fn yaml_no_start_with_dagrs() {
 
 #[test]
 fn yaml_task_no_name() {
-    let no_task_name: Result<Vec<Box<dyn Task>>, ParseError> =
+    let no_task_name: Result<Vec<Box<dyn Task>>, DagError> =
         YamlParser.parse_tasks("tests/config/no_task_name.yaml", HashMap::new());
     // let err = no_task_name.unwrap_err().to_string();
     // println!("{err}");
@@ -49,7 +49,7 @@ fn yaml_task_no_name() {
 
 #[test]
 fn yaml_task_not_found_precursor() {
-    let not_found_pre: Result<Vec<Box<dyn Task>>, ParseError> =
+    let not_found_pre: Result<Vec<Box<dyn Task>>, DagError> =
         YamlParser.parse_tasks("tests/config/precursor_not_found.yaml", HashMap::new());
     // let err = not_found_pre.unwrap_err().to_string();
     // println!("{err}");
@@ -58,7 +58,7 @@ fn yaml_task_not_found_precursor() {
 
 #[test]
 fn yaml_task_no_script_config() {
-    let script: Result<Vec<Box<dyn Task>>, ParseError> =
+    let script: Result<Vec<Box<dyn Task>>, DagError> =
         YamlParser.parse_tasks("tests/config/no_script.yaml", HashMap::new());
     // let err = script.unwrap_err().to_string();
     // println!("{err}");
@@ -67,7 +67,7 @@ fn yaml_task_no_script_config() {
 
 #[test]
 fn correct_parse() {
-    let tasks: Result<Vec<Box<dyn Task>>, ParseError> =
+    let tasks: Result<Vec<Box<dyn Task>>, DagError> =
         YamlParser.parse_tasks("tests/config/correct.yaml", HashMap::new());
     assert!(tasks.is_ok());
 }


### PR DESCRIPTION
This PR introduces error propagation. This is an improvement because we are now able to see, e.g.,  errors of individual tasks during the DAG construction.