### PR TITLE
Add graph reset function

### DIFF
--- a/src/engine/dag.rs
+++ b/src/engine/dag.rs
@@ -89,6 +89,17 @@ impl Dag {
         }
     }
 
+    /// Reset the graph state but keep the tasks.
+    pub fn reset(&mut self) {
+        self.rely_graph = Graph::new();
+        self.execute_states = HashMap::new();
+        self.env = Arc::new(EnvVar::new());
+        self.can_continue = Arc::new(AtomicBool::new(true));
+        self.exe_sequence = Vec::new();
+        self.keep_going = false;
+        self.keep_going_errored = Arc::new(AtomicBool::new(false));
+    }
+
     /// Create a dag by adding a series of tasks.
     pub fn with_tasks(tasks: Vec<impl Task + 'static>) -> Dag {
         let mut dag = Dag::new();


### PR DESCRIPTION
This PR adds a reset function to the API.

With this reset function we can construct a DAG once and execute it multiple times. This has been working fairly well for me for the past weeks during active testing.