### PR TITLE
Add ability to retrieve full output of tasks and some cmd fixes

### DIFF
--- a/src/task/state.rs
+++ b/src/task/state.rs
@@ -40,8 +40,8 @@ use std::{
     slice::Iter,
     sync::{
         atomic::{AtomicBool, Ordering},
-        Arc, Mutex,
-    },
+        Arc, Mutex
+    }
 };
 
 use tokio::sync::Semaphore;
@@ -93,7 +93,7 @@ pub(crate) struct ExecState {
 }
 
 /// Output produced by a task.
-#[derive(Debug)]
+#[derive(Clone,Debug)]
 pub enum Output {
     Out(Option<Content>),
     Err(String),
@@ -125,6 +125,9 @@ impl ExecState {
     /// This function is generally not called directly, but first uses the semaphore for synchronization control.
     pub(crate) fn get_output(&self) -> Option<Content> {
         self.output.lock().unwrap().get_out()
+    }
+    pub(crate) fn get_full_output(&self) -> Output {
+        self.output.lock().unwrap().clone()
     }
 
     /// The task execution succeed or not.


### PR DESCRIPTION
task/state.rs:
- New method to the full output

engine/dag.rs:
- Set the output on task errors
- New method to get the full output

task/cmd.rs:

- Get the status code regardless of result
- Output::new already wraps the type into Content, but error_with_exit_code does not