### PR TITLE
Fix error with code output

### DIFF
--- a/src/engine/dag.rs
+++ b/src/engine/dag.rs
@@ -370,7 +370,7 @@ impl Dag {
                         if out.is_err() {
                             let error = out.get_err().unwrap_or("".to_string());
                             error!(
-                                "Execution failed [name: {}, id: {}]\nerr: {}",
+                                "Execution failed [name: {}, id: {}] - err: {}",
                                 task_name, task_id, error
                             );
                             execute_state.set_output(out);

--- a/src/task/state.rs
+++ b/src/task/state.rs
@@ -199,9 +199,9 @@ impl Output {
         match self {
             Self::Out(_) => None,
             Self::Err(err) => Some(err.to_string()),
-            Self::ErrWithExitCode(_, err) => {
-                if let Some(e) = err {
-                    Some(e.get::<String>()?.to_string())
+            Self::ErrWithExitCode(code, err) => {
+                if code.is_some() || err.is_some() {
+                    Some(format!("code: {code:?} - {err:?}"))
                 } else {
                     None
                 }


### PR DESCRIPTION
Two commits, one to remove a linefeed from an error log to keep logs consistent. The second to fix the error output in the case of ErrWithExitCode so that the code is displayed if present.