### PR TITLE
Parser: auto_graph macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ log = "0.4"
 env_logger = "0.10.1"
 async-trait = "0.1.83"
 derive = { path = "derive", optional = true }
+proc-macro2 = "1.0"
 
 [dev-dependencies]
 simplelog = "0.12"

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -1,7 +1,7 @@
 use proc_macro::TokenStream;
-
 #[cfg(feature = "derive")]
 mod auto_node;
+mod relay;
 
 /// [`auto_node`] is a macro that may be used when customizing nodes. It can only be
 /// marked on named struct or unit struct.
@@ -37,4 +37,16 @@ mod auto_node;
 pub fn auto_node(args: TokenStream, input: TokenStream) -> TokenStream {
     use crate::auto_node::auto_node;
     auto_node(args, input).into()
+}
+
+/// The [`dependencies!`] macro allows users to specify all task dependencies in an easy-to-understand
+/// way. It will return the generated graph structure based on a set of defined dependencies
+#[cfg(feature = "derive")]
+#[proc_macro]
+pub fn dependencies(input: TokenStream) -> TokenStream {
+    use relay::add_relay;
+    use relay::Relaies;
+    let relaies = syn::parse_macro_input!(input as Relaies);
+    let token = add_relay(relaies);
+    token.into()
 }

--- a/derive/src/relay.rs
+++ b/derive/src/relay.rs
@@ -1,0 +1,106 @@
+use std::collections::{HashMap, HashSet};
+
+use proc_macro2::Ident;
+use syn::{parse::Parse, Token};
+
+/// Parses and processes a set of relay tasks and their successors, and generates a directed graph.
+///
+/// Step 1: Define the `Relay` struct with a task and its associated successors (other tasks that depend on it).
+///
+/// Step 2: Implement the `Parse` trait for `Relaies` to parse a sequence of task-successor pairs from input. This creates a vector of `Relay` objects.
+///
+/// Step 3: In `add_relay`, initialize a directed graph structure using `Graph` and a hash map to store edges between nodes.
+///
+/// Step 4: Iterate through each `Relay` and update the graph's edge list by adding nodes (tasks) and defining edges between tasks and their successors.
+///
+/// Step 5: Ensure that each task is only added once to the graph using a cache (`HashSet`) to avoid duplicates.
+///
+/// Step 6: Populate the edges of the graph with the previously processed data and return the graph.
+///
+/// This code provides the logic to dynamically build a graph based on parsed task relationships, where each task is a node and the successors define directed edges between nodes.
+
+pub(crate) struct Relay {
+    pub(crate) task: Ident,
+    pub(crate) successors: Vec<Ident>,
+}
+
+pub(crate) struct Relaies(pub(crate) Vec<Relay>);
+
+impl Parse for Relaies {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let mut relies = Vec::new();
+        loop {
+            let mut successors = Vec::new();
+            let task = input.parse::<Ident>()?;
+            input.parse::<syn::Token!(->)>()?;
+            while !input.peek(Token!(,)) && !input.is_empty() {
+                successors.push(input.parse::<Ident>()?);
+            }
+            let relay = Relay { task, successors };
+            relies.push(relay);
+            let _ = input.parse::<Token!(,)>();
+            if input.is_empty() {
+                break;
+            }
+        }
+        Ok(Self(relies))
+    }
+}
+
+pub(crate) fn add_relay(relaies: Relaies) -> proc_macro2::TokenStream {
+    let mut token = proc_macro2::TokenStream::new();
+    let mut cache: HashSet<Ident> = HashSet::new();
+    token.extend(quote::quote!(
+        use dagrs::Graph;
+        use dagrs::NodeId;
+        use std::collections::HashMap;
+        use std::collections::HashSet;
+        let mut edge: HashMap<NodeId, HashSet<NodeId>> = HashMap::new();
+        let mut graph = Graph::new();
+    ));
+    for relay in relaies.0.iter() {
+        let task = relay.task.clone();
+        token.extend(quote::quote!(
+            let task_id = #task.id();
+            if(!edge.contains_key(&task_id)){
+                edge.insert(task_id, HashSet::new());
+            }
+        ));
+        for successor in relay.successors.iter() {
+            token.extend(quote::quote!(
+                let successor_id = #successor.id();
+                edge.entry(task_id)
+                .or_insert_with(HashSet::new)
+                .insert(successor_id);
+            ));
+        }
+    }
+    for relay in relaies.0.iter() {
+        let task = relay.task.clone();
+        if (!cache.contains(&task)) {
+            token.extend(quote::quote!(
+                graph.add_node(Box::new(#task));
+            ));
+            cache.insert(task);
+        }
+        for successor in relay.successors.iter() {
+            if (!cache.contains(successor)) {
+                token.extend(quote::quote!(
+                    graph.add_node(Box::new(#successor));
+                ));
+                cache.insert(successor.clone());
+            }
+        }
+    }
+    token.extend(quote::quote!(for (key, value) in &edge {
+        let vec = value.iter().cloned().collect();
+        graph.add_edge(key.clone(), vec);
+    }));
+
+    quote::quote!(
+        {
+            #token;
+            graph
+        }
+    )
+}

--- a/examples/auto_relay.rs
+++ b/examples/auto_relay.rs
@@ -1,0 +1,45 @@
+use std::sync::Arc;
+
+use dagrs::{
+    auto_node, dependencies,
+    graph::{self, graph::Graph},
+    EmptyAction, EnvVar, InChannels, Node, NodeTable, OutChannels,
+};
+
+#[auto_node]
+struct MyNode {/*Put customized fields here.*/}
+
+fn main() {
+    let mut node_table = NodeTable::default();
+
+    let node_name = "auto_node".to_string();
+
+    let s = MyNode {
+        id: node_table.alloc_id_for(&node_name),
+        name: node_name.clone(),
+        input_channels: InChannels::default(),
+        output_channels: OutChannels::default(),
+        action: Box::new(EmptyAction),
+    };
+
+    let a = MyNode {
+        id: node_table.alloc_id_for(&node_name),
+        name: node_name.clone(),
+        input_channels: InChannels::default(),
+        output_channels: OutChannels::default(),
+        action: Box::new(EmptyAction),
+    };
+
+    let b = MyNode {
+        id: node_table.alloc_id_for(&node_name),
+        name: node_name.clone(),
+        input_channels: InChannels::default(),
+        output_channels: OutChannels::default(),
+        action: Box::new(EmptyAction),
+    };
+    let mut g = dependencies!(s -> a b,
+     b -> a
+    );
+
+    g.run();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@ pub use node::{
     default_node::DefaultNode,
     node::*,
 };
+
+pub use graph::graph::*;
 pub use tokio;
 pub use utils::{env::EnvVar, output::Output};
 


### PR DESCRIPTION
# auto_graph

The auto_graph macro is used in DAGRS to automate the generation of corresponding graph structures for provided dependencies, where nodes can be any custom nodes that implement the node trait, and only the dependencies between nodes need to be provided

# example

Firstly, it is necessary to define the nodes that have implemented the node trait

```rust
let s = MyNode {
        id: node_table.alloc_id_for(&node_name),
        name: node_name.clone(),
        input_channels: InChannels::default(),
        output_channels: OutChannels::default(),
        action: Box::new(EmptyAction),
    };

let a = MyNode {
        id: node_table.alloc_id_for(&node_name),
        name: node_name.clone(),
        input_channels: InChannels::default(),
        output_channels: OutChannels::default(),
        action: Box::new(EmptyAction),
    };

let b = MyNode {
        id: node_table.alloc_id_for(&node_name),
        name: node_name.clone(),
        input_channels: InChannels::default(),
        output_channels: OutChannels::default(),
        action: Box::new(EmptyAction),
    };
```



When we input the following dependency relationships

```rust
dependencies!(
     s -> a b,
     b -> a
);
```



Auto_graph can help us automate the generation of a graph structure

## Related issue

https://github.com/dagrs-dev/dagrs/issues/74



































