### PR TITLE
Conditional Node

### DIFF
--- a/examples/dagrs-sklearn/examples/sklearn.rs
+++ b/examples/dagrs-sklearn/examples/sklearn.rs
@@ -44,6 +44,7 @@ impl Action for NodeAction {
                 code,
                 content.unwrap().get::<(Vec<String>, Vec<String>)>()
             ),
+            _ => panic!(),
         };
         Output::empty()
     }

--- a/src/node/conditional_node.rs
+++ b/src/node/conditional_node.rs
@@ -1,0 +1,92 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::{EnvVar, InChannels, Node, NodeId, NodeName, NodeTable, OutChannels, Output};
+
+/// # `Condition` trait
+///
+/// The [`Condition`] trait trait defines the condition logic for a [`ConditionalNode`].
+/// The `run` method evaluates the condition based on input channels, output channels and environment variables.
+/// Returns a boolean indicating whether the condition is met.
+#[async_trait]
+pub trait Condition: Send + Sync {
+    async fn run(
+        &self,
+        in_channels: &mut InChannels,
+        out_channels: &OutChannels,
+        env: Arc<EnvVar>,
+    ) -> bool;
+}
+
+/// # Conditional node type
+///
+/// [`ConditionalNode`] is a node type that executes based on a condition.
+/// It can evaluate the condition using input channels, output channels and environment variables.
+/// The condition logic is defined by implementing the [`Condition`] trait.
+///
+/// When the condition is met during execution, Dagrs will continue running.
+/// If the condition is not met, Dagrs will stop on this node.
+pub struct ConditionalNode {
+    id: NodeId,
+    name: NodeName,
+    condition: Box<dyn Condition>,
+    in_channels: InChannels,
+    out_channels: OutChannels,
+}
+
+impl ConditionalNode {
+    /// Creates a new [`ConditionalNode`] with the given name and condition.
+    /// The [`Condition`] determines whether execution should continue or stop at this node.
+    /// The [`NodeTable`] is used to allocate a unique ID for this node.
+    pub fn with_condition(
+        name: NodeName,
+        condition: impl Condition + 'static,
+        node_table: &mut NodeTable,
+    ) -> Self {
+        Self {
+            id: node_table.alloc_id_for(&name),
+            name,
+            condition: Box::new(condition),
+            in_channels: InChannels::default(),
+            out_channels: OutChannels::default(),
+        }
+    }
+}
+
+#[async_trait]
+impl Node for ConditionalNode {
+    /// Returns the unique identifier of this conditional node
+    fn id(&self) -> NodeId {
+        self.id
+    }
+
+    /// Returns the name of this conditional node
+    fn name(&self) -> NodeName {
+        self.name.clone()
+    }
+
+    /// Returns a mutable reference to the input channels of this node
+    fn input_channels(&mut self) -> &mut InChannels {
+        &mut self.in_channels
+    }
+
+    /// Returns a mutable reference to the output channels of this node
+    fn output_channels(&mut self) -> &mut OutChannels {
+        &mut self.out_channels
+    }
+
+    /// Executes the condition logic of this node
+    async fn run(&mut self, env: Arc<EnvVar>) -> Output {
+        Output::ConditionResult(
+            self.condition
+                .run(&mut self.in_channels, &self.out_channels, env)
+                .await,
+        )
+    }
+
+    /// Returns true since this is a conditional node
+    fn is_condition(&self) -> bool {
+        true
+    }
+}

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1,4 +1,5 @@
 pub mod action;
+pub mod conditional_node;
 pub mod default_node;
 pub mod id_allocate;
 pub mod node;

--- a/src/node/node.rs
+++ b/src/node/node.rs
@@ -30,6 +30,10 @@ pub trait Node: Send + Sync {
     fn output_channels(&mut self) -> &mut OutChannels;
     /// Execute a run of this node.
     async fn run(&mut self, env: Arc<EnvVar>) -> Output;
+    /// Return true if this node is conditional node. By default, it returns false.
+    fn is_condition(&self) -> bool {
+        false
+    }
 }
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]

--- a/src/utils/output.rs
+++ b/src/utils/output.rs
@@ -33,6 +33,8 @@ pub enum Output {
     Out(Option<Content>),
     Err(String),
     ErrWithExitCode(Option<i32>, Option<Content>),
+    /// ...
+    ConditionResult(bool),
 }
 
 impl Output {
@@ -63,7 +65,7 @@ impl Output {
     pub(crate) fn is_err(&self) -> bool {
         match self {
             Self::Err(_) | Self::ErrWithExitCode(_, _) => true,
-            Self::Out(_) => false,
+            Self::Out(_) | Self::ConditionResult(_) => false,
         }
     }
 
@@ -71,19 +73,30 @@ impl Output {
     pub fn get_out(&self) -> Option<Content> {
         match self {
             Self::Out(ref out) => out.clone(),
-            Self::Err(_) | Self::ErrWithExitCode(_, _) => None,
+            Self::Err(_) | Self::ErrWithExitCode(_, _) | Self::ConditionResult(_) => None,
         }
     }
 
     /// Get error information stored in [`Output`].
     pub fn get_err(&self) -> Option<String> {
         match self {
-            Self::Out(_) => None,
+            Self::Out(_) | Self::ConditionResult(_) => None,
             Self::Err(err) => Some(err.to_string()),
             Self::ErrWithExitCode(code, _) => {
                 let error_code = code.map_or("".to_string(), |v| v.to_string());
                 Some(format!("code: {error_code}"))
             }
+        }
+    }
+
+    /// Get the condition result stored in [`Output`].
+    ///
+    /// Returns `Some(bool)` if this is a `ConditionResult` variant,
+    /// otherwise returns `None`.
+    pub(crate) fn conditional_result(&self) -> Option<bool> {
+        match self {
+            Self::ConditionResult(b) => Some(*b),
+            _ => None,
         }
     }
 }


### PR DESCRIPTION
# Add Conditional Node Support

This PR introduces a new `ConditionalNode` type and updates the graph execution logic to support conditional workflows.

## Key Changes

### New Features
- Added `ConditionalNode`: A specialized node type that can control the execution flow based on custom conditions
- Implemented block-based execution in the graph, where nodes are grouped into blocks separated by conditional nodes
- Added support for early termination of subsequent blocks when a condition fails

### Graph Execution Changes
- Modified `Graph::check_loop()` to not only detect cycles but also divide nodes into execution blocks
- Updated `Graph::run()` to execute nodes block by block
- Added ability to abort remaining blocks when a condition evaluates to false

### Example Usage
Added a example (`examples/conditional_node.rs`) demonstrating:
- A DAG with conditional branching
- Block-based execution flow
- Early termination based on condition results

```
//!    ┌───────────↴
//!    B ──→ E ──→ X ──→ G
//!  ↗     ↗           ↗
//! A ───→ C          ╱
//!  ↘     ↘        ╱
//!    D ───→ F ───╱
//! The node `X` is a conditional node which will return false.
//!
//! Dagrs will split the graph into two blocks:     
//! - A, B, C, D, E, F, X
//! - G
//!
//! Since node X's condition (VerifyGT(128)) is not met, execution stops at node X and never reaches node G.
//! Therefore G's result should be None.
```
