### PR TITLE
Support Loop Subgraph Structure and Improve Channel Mutability

### DIFF
--- a/dagrs-derive/src/auto_node.rs
+++ b/dagrs-derive/src/auto_node.rs
@@ -172,7 +172,7 @@ fn impl_run(
     quote::quote!(
         async fn run(&mut self, env: std::sync::Arc<dagrs::EnvVar>) -> dagrs::Output {
             self.#ident
-                .run(&mut self.#in_channels_ident, &self.#out_channels_ident, env)
+                .run(&mut self.#in_channels_ident, &mut self.#out_channels_ident, env)
                 .await
         }
     )

--- a/examples/compute_dag.rs
+++ b/examples/compute_dag.rs
@@ -25,7 +25,7 @@ impl Action for Compute {
     async fn run(
         &self,
         in_channels: &mut InChannels,
-        out_channels: &OutChannels,
+        out_channels: &mut OutChannels,
         env: Arc<EnvVar>,
     ) -> Output {
         let base = env.get::<usize>(BASE).unwrap();

--- a/examples/conditional_node.rs
+++ b/examples/conditional_node.rs
@@ -35,7 +35,7 @@ impl Action for Compute {
     async fn run(
         &self,
         in_channels: &mut InChannels,
-        out_channels: &OutChannels,
+        out_channels: &mut OutChannels,
         env: Arc<EnvVar>,
     ) -> Output {
         let base = env.get::<usize>(BASE).unwrap();

--- a/examples/dagrs-sklearn/examples/sklearn.rs
+++ b/examples/dagrs-sklearn/examples/sklearn.rs
@@ -14,7 +14,7 @@ impl Action for NodeAction {
     async fn run(
         &self,
         _: &mut InChannels,
-        out_channels: &OutChannels,
+        out_channels: &mut OutChannels,
         env: Arc<EnvVar>,
     ) -> Output {
         let data_src: &&str = env.get_ref(ENV_DATA_SRC).unwrap();
@@ -28,7 +28,7 @@ impl Action for NodeAction {
             ],
         );
         let result = cmd_act
-            .run(&mut InChannels::default(), &OutChannels::default(), env)
+            .run(&mut InChannels::default(), &mut OutChannels::default(), env)
             .await;
         match result {
             Output::Out(content) => {
@@ -59,7 +59,12 @@ impl NodeAction {
 struct RootAction;
 #[async_trait]
 impl Action for RootAction {
-    async fn run(&self, in_channels: &mut InChannels, _: &OutChannels, env: Arc<EnvVar>) -> Output {
+    async fn run(
+        &self,
+        in_channels: &mut InChannels,
+        _: &mut OutChannels,
+        env: Arc<EnvVar>,
+    ) -> Output {
         let data_src: &&str = env.get_ref(ENV_DATA_SRC).unwrap();
         let mut thetas: Vec<String> = in_channels
             .map(|theta| {
@@ -75,7 +80,7 @@ impl Action for RootAction {
 
         let cmd_action = CommandAction::new("python", args);
         cmd_action
-            .run(&mut InChannels::default(), &OutChannels::default(), env)
+            .run(&mut InChannels::default(), &mut OutChannels::default(), env)
             .await
     }
 }

--- a/examples/dagrs-sklearn/src/command_action.rs
+++ b/examples/dagrs-sklearn/src/command_action.rs
@@ -24,7 +24,7 @@ impl Action for CommandAction {
     async fn run(
         &self,
         in_channels: &mut dagrs::InChannels,
-        out_channels: &dagrs::OutChannels,
+        out_channels: &mut dagrs::OutChannels,
         _: std::sync::Arc<dagrs::EnvVar>,
     ) -> dagrs::Output {
         let mut args = Vec::new();

--- a/examples/hello_dagrs.rs
+++ b/examples/hello_dagrs.rs
@@ -14,7 +14,7 @@ use dagrs::{
 pub struct HelloAction;
 #[async_trait]
 impl Action for HelloAction {
-    async fn run(&self, _: &mut InChannels, _: &OutChannels, _: Arc<EnvVar>) -> Output {
+    async fn run(&self, _: &mut InChannels, _: &mut OutChannels, _: Arc<EnvVar>) -> Output {
         Output::Out(Some(Content::new("Hello Dagrs".to_string())))
     }
 }

--- a/examples/loop_dag.rs
+++ b/examples/loop_dag.rs
@@ -1,0 +1,157 @@
+//! IN
+//! |          +----------+
+//! |          ↓          |
+//! +-----> INTER ----> PROC
+//！
+//！ A loop dag where K is the starter ("kicker") process, that emits a single packet containing a blank,
+//! (imagine) INTER controls a screen. In this figure, INTER receives some data from PROC, displays it on
+//! the screen, and then sends information back to PROC.
+//! If the software infrastructure allows it, waiting for input need only suspend INTER, and other processes
+//! could be working on their input while INTER is suspended.
+
+use std::{env, fmt::Display, sync::Arc};
+
+use async_trait::async_trait;
+use dagrs::{
+    graph::loop_subgraph::LoopSubgraph, Action, Content, DefaultNode, EnvVar, Graph, InChannels,
+    Node, NodeId, NodeTable, OutChannels, Output,
+};
+
+struct InAction;
+
+/// Send a unit to the INTER node.
+#[async_trait]
+impl Action for InAction {
+    async fn run(
+        &self,
+        _in_channels: &mut InChannels,
+        out_channels: &mut OutChannels,
+        _env: Arc<EnvVar>,
+    ) -> Output {
+        log::info!("`In` send start signal to INTER node");
+        out_channels.broadcast(Content::new(())).await;
+        Output::Out(None)
+    }
+}
+
+struct InterAction {
+    in_id: NodeId,
+    proc_id: NodeId,
+    limit: usize,
+}
+
+#[async_trait]
+impl Action for InterAction {
+    async fn run(
+        &self,
+        in_channels: &mut InChannels,
+        out_channels: &mut OutChannels,
+        _env: Arc<EnvVar>,
+    ) -> Output {
+        // Recv a start signal from the IN node.
+        let content = in_channels.recv_from(&self.in_id).await.unwrap();
+        in_channels.close_async(&self.in_id).await;
+        log::info!("`Inter` Received start signal from IN node");
+
+        let mut times = 0usize;
+
+        out_channels.send_to(&self.proc_id, content).await.unwrap();
+        log::info!("`Inter` send start signal to PROC node");
+
+        while let Ok(content) = in_channels.recv_from(&self.proc_id).await {
+            // Simulate screen display and user input
+            log::info!(
+                "`Inter` Displaying input: [{}]",
+                content.get::<Arc<dyn Display + Send + Sync>>().unwrap()
+            );
+            out_channels.send_to(&self.proc_id, content).await.unwrap();
+            log::info!("`Inter` send output to PROC node");
+
+            times += 1;
+            if times >= self.limit {
+                log::info!("`Inter` reached iter limit {}, exit", times);
+                out_channels.close(&self.proc_id);
+                break;
+            }
+        }
+
+        log::info!("`Inter` exit");
+        Output::empty()
+    }
+}
+
+struct ProcAction {
+    inter_node: NodeId,
+}
+
+#[async_trait]
+impl Action for ProcAction {
+    async fn run(
+        &self,
+        in_channels: &mut InChannels,
+        out_channels: &mut OutChannels,
+        _env: Arc<EnvVar>,
+    ) -> Output {
+        let mut times = 0usize;
+        while let Ok(_) = in_channels.recv_from(&self.inter_node).await {
+            log::info!("`Proc` send {} to INTER node", times);
+            out_channels
+                .send_to(
+                    &self.inter_node,
+                    Content::new(Arc::new(times) as Arc<dyn Display + Send + Sync>),
+                )
+                .await
+                .unwrap();
+            times += 1;
+        }
+
+        log::info!("`Proc` exit");
+        Output::empty()
+    }
+}
+
+fn main() {
+    env::set_var("RUST_LOG", "info");
+    env_logger::init();
+
+    let mut node_table = NodeTable::default();
+
+    // Create nodes
+    let in_node = DefaultNode::with_action("IN".to_string(), InAction, &mut node_table);
+    let in_id = in_node.id();
+
+    let mut inter = DefaultNode::new("Inter".to_string(), &mut node_table);
+    let inter_id = inter.id();
+
+    let mut proc = DefaultNode::new("Proc".to_string(), &mut node_table);
+    let proc_id = proc.id();
+
+    inter.set_action(InterAction {
+        in_id,
+        proc_id,
+        limit: 10,
+    });
+    proc.set_action(ProcAction {
+        inter_node: inter_id,
+    });
+
+    let mut inter_proc = LoopSubgraph::new("inter_proc".to_string(), &mut node_table);
+    inter_proc.add_node(inter);
+    inter_proc.add_node(proc);
+
+    // Create graph and add nodes
+    let mut graph = Graph::new();
+    graph.add_node(in_node);
+    graph.add_node(inter_proc);
+
+    // Set up dependencies to create the loop
+    graph.add_edge(in_id, vec![inter_id]);
+    graph.add_edge(inter_id, vec![proc_id]);
+    graph.add_edge(proc_id, vec![inter_id]);
+
+    // Execute graph
+    match graph.start() {
+        Ok(_) => println!("Graph executed successfully"),
+        Err(e) => panic!("Graph execution failed: {:?}", e),
+    }
+}

--- a/src/connection/in_channel.rs
+++ b/src/connection/in_channel.rs
@@ -54,6 +54,14 @@ impl InChannels {
         join_all(futures).await.into_iter().map(|x| f(x)).collect()
     }
 
+    /// Close the channel by the given `NodeId` asynchronously, and remove the channel in this map.
+    pub async fn close_async(&mut self, id: &NodeId) {
+        if let Some(c) = self.get(id) {
+            c.lock().await.close();
+            self.0.remove(id);
+        }
+    }
+
     /// Close the channel by the given `NodeId`, and remove the channel in this map.
     pub fn close(&mut self, id: &NodeId) {
         if let Some(c) = self.get(id) {

--- a/src/graph/abstract_graph.rs
+++ b/src/graph/abstract_graph.rs
@@ -1,0 +1,158 @@
+use crate::node::node::NodeId;
+use std::collections::{HashMap, HashSet, VecDeque};
+
+/// A simplified graph structure used for cycle detection
+pub(crate) struct AbstractGraph {
+    /// Maps node IDs to their in-degrees
+    pub in_degree: HashMap<NodeId, usize>,
+    /// Maps node IDs to their outgoing edges (destination node IDs)
+    pub edges: HashMap<NodeId, HashSet<NodeId>>,
+    /// Maps folded node IDs to their abstract node IDs
+    pub folded_nodes: HashMap<NodeId, NodeId>,
+    /// Maps abstract node IDs to concrete node IDs
+    pub unfold_abstract_nodes: HashMap<NodeId, Vec<NodeId>>,
+}
+
+impl AbstractGraph {
+    /// Creates a new empty abstract graph
+    pub fn new() -> Self {
+        Self {
+            in_degree: HashMap::new(),
+            edges: HashMap::new(),
+            folded_nodes: HashMap::new(),
+            unfold_abstract_nodes: HashMap::new(),
+        }
+    }
+
+    /// Adds a node to the abstract graph
+    pub fn add_node(&mut self, node_id: NodeId) {
+        if !self.in_degree.contains_key(&node_id) {
+            self.in_degree.insert(node_id, 0);
+            self.edges.insert(node_id, HashSet::new());
+        }
+    }
+
+    /// Adds an edge between two nodes in the abstract graph
+    pub fn add_edge(&mut self, from: NodeId, to: NodeId) {
+        // Look up the abstract node ID that a concrete node ID has been folded into.
+        let mut abstract_flag_from = false;
+        let mut abstract_flag_to = false;
+        let from = if let Some(abstract_id) = self.get_abstract_node_id(&from) {
+            abstract_flag_from = true;
+            *abstract_id
+        } else {
+            from
+        };
+        let to = if let Some(abstract_id) = self.get_abstract_node_id(&to) {
+            abstract_flag_to = true;
+            *abstract_id
+        } else {
+            to
+        };
+
+        // If both `from` and `to` are abstract node IDs and `from` == `to`, skip the edge addition
+        if abstract_flag_from && abstract_flag_to && from == to {
+            return;
+        }
+
+        log::debug!("Adding edge from {:?} to {:?}", from, to);
+
+        self.edges.get_mut(&from).unwrap().insert(to);
+        *self.in_degree.get_mut(&to).unwrap() += 1;
+    }
+
+    /// Adds a folded node to the abstract graph
+    pub fn add_folded_node(&mut self, abstract_node_id: NodeId, concrete_node_id: Vec<NodeId>) {
+        self.add_node(abstract_node_id);
+
+        for concrete_id in &concrete_node_id {
+            self.folded_nodes.insert(*concrete_id, abstract_node_id);
+        }
+
+        self.unfold_abstract_nodes
+            .insert(abstract_node_id, concrete_node_id);
+    }
+
+    /// Look up the concrete node IDs that an abstract node ID has been unfolded into.
+    pub fn unfold_node(&self, abstract_node_id: NodeId) -> Option<&Vec<NodeId>> {
+        self.unfold_abstract_nodes.get(&abstract_node_id)
+    }
+
+    /// Look up the abstract node ID that a concrete node ID has been folded into.
+    /// Returns None if the node ID has not been folded into an abstract node.
+    pub fn get_abstract_node_id(&self, node_id: &NodeId) -> Option<&NodeId> {
+        self.folded_nodes.get(node_id)
+    }
+
+    /// Returns the total number of nodes in the abstract graph
+    pub fn size(&self) -> usize {
+        self.in_degree.len()
+    }
+
+    /// Check if the graph contains any cycles/loops using a topological sorting approach.
+    /// Returns true if the graph contains a cycle, false otherwise.
+    pub fn check_loop(&self) -> bool {
+        let mut in_degree = self.in_degree.clone();
+        let mut visited_count = 0;
+
+        // Start with nodes that have 0 in-degree
+        let mut queue: VecDeque<NodeId> = in_degree
+            .iter()
+            .filter_map(|(&node, &degree)| if degree == 0 { Some(node) } else { None })
+            .collect();
+
+        while let Some(node) = queue.pop_front() {
+            log::debug!("Visiting node: {:?}", node);
+            visited_count += 1;
+
+            // For each outgoing edge
+            if let Some(nexts) = self.edges.get(&node) {
+                // Decrease in-degree of the target node
+                for next in nexts {
+                    let degree = in_degree.get_mut(next).unwrap();
+                    *degree -= 1;
+                    // If in-degree becomes 0, add to queue
+                    if *degree == 0 {
+                        queue.push_back(*next);
+                    }
+                }
+            }
+        }
+
+        // If we haven't visited all nodes, there must be a cycle (visited_count != size)
+        log::debug!("Visited count: {}, Size: {}", visited_count, self.size());
+        visited_count != self.size()
+    }
+}
+
+#[cfg(test)]
+mod abstract_graph_test {
+    use super::*;
+
+    /// Tests the cycle detection functionality of the graph.
+    /// Creates a graph with two nodes (1 and 2) and adds edges to form a cycle:
+    /// Node 1 <-> Node 2
+    /// check_loop() returns true.
+    #[test]
+    fn test_check_loop() {
+        let mut graph = AbstractGraph::new();
+        graph.add_node(NodeId(1));
+        graph.add_node(NodeId(2));
+        graph.add_edge(NodeId(1), NodeId(2));
+        graph.add_edge(NodeId(2), NodeId(1));
+        assert!(graph.check_loop());
+    }
+
+    /// Tests the cycle detection functionality of the graph.
+    /// Creates a graph with two nodes (1 and 2) and adds a single directed edge:
+    /// Node 1 -> Node 2
+    /// Since there is no cycle in this graph, check_loop() returns false.
+    #[test]
+    fn test_check_no_loop() {
+        let mut graph = AbstractGraph::new();
+        graph.add_node(NodeId(1));
+        graph.add_node(NodeId(2));
+        graph.add_edge(NodeId(1), NodeId(2));
+        assert!(!graph.check_loop());
+    }
+}

--- a/src/graph/loop_subgraph.rs
+++ b/src/graph/loop_subgraph.rs
@@ -1,0 +1,63 @@
+use async_trait::async_trait;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+use crate::{EnvVar, InChannels, Node, NodeId, NodeName, NodeTable, OutChannels, Output};
+
+/// A special node type that represents a subgraph of nodes in a loop structure.
+///
+/// The LoopSubgraph is included in the main graph as a single node, but internally contains
+/// multiple nodes that will be executed repeatedly. The connection and execution of the loop is controlled
+/// by the parent graph rather than the LoopSubgraph itself.
+pub struct LoopSubgraph {
+    id: NodeId,
+    name: NodeName,
+    in_channels: InChannels,
+    out_channels: OutChannels,
+    // Inner nodes, contains the nodes that need to be executed in a loop
+    inner_nodes: Vec<Arc<Mutex<dyn Node>>>,
+}
+
+impl LoopSubgraph {
+    pub fn new(name: NodeName, node_table: &mut NodeTable) -> Self {
+        Self {
+            id: node_table.alloc_id_for(&name),
+            name,
+            in_channels: InChannels::default(),
+            out_channels: OutChannels::default(),
+            inner_nodes: Vec::new(),
+        }
+    }
+
+    /// Add a node to the subgraph
+    pub fn add_node(&mut self, node: impl Node + 'static) {
+        self.inner_nodes.push(Arc::new(Mutex::new(node)));
+    }
+}
+
+#[async_trait]
+impl Node for LoopSubgraph {
+    fn id(&self) -> NodeId {
+        self.id
+    }
+
+    fn name(&self) -> NodeName {
+        self.name.clone()
+    }
+
+    fn input_channels(&mut self) -> &mut InChannels {
+        &mut self.in_channels
+    }
+
+    fn output_channels(&mut self) -> &mut OutChannels {
+        &mut self.out_channels
+    }
+
+    fn loop_structure(&self) -> Option<Vec<Arc<Mutex<dyn Node>>>> {
+        Some(self.inner_nodes.clone())
+    }
+
+    async fn run(&mut self, _: Arc<EnvVar>) -> Output {
+        panic!("Loop subgraph is not executed directly, it will be executed by the parent graph.");
+    }
+}

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -1,2 +1,4 @@
+mod abstract_graph;
 pub mod error;
 pub mod graph;
+pub mod loop_subgraph;

--- a/src/node/action.rs
+++ b/src/node/action.rs
@@ -27,7 +27,7 @@ use crate::{
 ///
 /// #[async_trait]
 /// impl Action for HelloAction{
-///     async fn run(&self, _: &mut InChannels, _: &OutChannels, _: Arc<EnvVar>) -> Output{
+///     async fn run(&self, _: &mut InChannels, _: &mut OutChannels, _: Arc<EnvVar>) -> Output{
 ///         for i in 0..self.repeat {
 ///             println!("{}",self.statement);
 ///         }
@@ -46,7 +46,7 @@ pub trait Action: Send + Sync {
     async fn run(
         &self,
         in_channels: &mut InChannels,
-        out_channels: &OutChannels,
+        out_channels: &mut OutChannels,
         env: Arc<EnvVar>,
     ) -> Output;
 }
@@ -57,7 +57,7 @@ pub trait Action: Send + Sync {
 pub struct EmptyAction;
 #[async_trait]
 impl Action for EmptyAction {
-    async fn run(&self, _: &mut InChannels, _: &OutChannels, _: Arc<EnvVar>) -> Output {
+    async fn run(&self, _: &mut InChannels, _: &mut OutChannels, _: Arc<EnvVar>) -> Output {
         Output::Out(None)
     }
 }

--- a/src/node/default_node.rs
+++ b/src/node/default_node.rs
@@ -72,7 +72,7 @@ impl Node for DefaultNode {
 
     async fn run(&mut self, env: Arc<EnvVar>) -> Output {
         self.action
-            .run(&mut self.in_channels, &self.out_channels, env)
+            .run(&mut self.in_channels, &mut self.out_channels, env)
             .await
     }
 }
@@ -123,7 +123,7 @@ mod test_default_node {
     pub struct HelloAction;
     #[async_trait]
     impl Action for HelloAction {
-        async fn run(&self, _: &mut InChannels, _: &OutChannels, _: Arc<EnvVar>) -> Output {
+        async fn run(&self, _: &mut InChannels, _: &mut OutChannels, _: Arc<EnvVar>) -> Output {
             Output::Out(Some(Content::new("Hello world".to_string())))
         }
     }

--- a/src/node/node.rs
+++ b/src/node/node.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
+use tokio::sync::Mutex;
 
 use crate::{
     connection::{in_channel::InChannels, out_channel::OutChannels},
@@ -33,6 +34,15 @@ pub trait Node: Send + Sync {
     /// Return true if this node is conditional node. By default, it returns false.
     fn is_condition(&self) -> bool {
         false
+    }
+    /// Returns the list of nodes that are part of this node's loop structure, if any.
+    ///
+    /// This method is used to identify nodes that are part of a loop-like structure, such as a loop subgraph.
+    /// When this method returns Some(nodes), the loop detection check will skip checking these nodes for cycles.
+    ///
+    /// Returns None by default, indicating this is not a loop-containing node.
+    fn loop_structure(&self) -> Option<Vec<Arc<Mutex<dyn Node>>>> {
+        None
     }
 }
 


### PR DESCRIPTION
1. Implemented `LoopSubgraph` structure to support cyclic execution patterns in DAG. Loop checking is moved to `abstract_graph`.

The `LoopSubgraph` is a special node type that folds a group of nodes that need to be executed in a loop. It implements the `Node` trait but delegates the actual execution to its parent graph, allowing for controlled cyclic execution patterns while maintaining the DAG structure at the macro level.

The `loop_dag.rs` example demonstrates a use case with three nodes:
```
//! IN
//! |          +----------+
//! |          ↓          |
//! +-----> INTER ----> PROC
//！ A loop dag where K is the starter ("kicker") process, that emits a single packet containing a blank,
//! (imagine) INTER controls a screen. In this figure, INTER receives some data from PROC, displays it on
//! the screen, and then sends information back to PROC.
//! If the software infrastructure allows it, waiting for input need only suspend INTER, and other processes
//! could be working on their input while INTER is suspended.
```

2. Modified `OutChannel` and `Action` trait to use mutable references of `OutChannels` for more convenient channel control.