### PR TITLE
Add Ord and PartialOrd traits to NodeId to enable sorting

### DIFF
--- a/src/node/node.rs
+++ b/src/node/node.rs
@@ -46,7 +46,7 @@ pub trait Node: Send + Sync {
     }
 }
 
-#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy, Ord, PartialOrd)]
 pub struct NodeId(pub(crate) usize);
 
 pub type NodeName = String;


### PR DESCRIPTION
Add Ord and PartialOrd traits to NodeId to enable sorting.  This is useful for iterating through the results in order.