### PR TITLE
Typed Channels

### DIFF
--- a/examples/typed_action.rs
+++ b/examples/typed_action.rs
@@ -1,0 +1,122 @@
+//! Use [`TypedAction`] to rewrite compute_dag.rs
+//!
+//! Only use Dag, execute a job. The graph is as follows:
+//!
+//!    ↱----------↴
+//!    B -→ E --→ G
+//!  ↗    ↗     ↗
+//! A --→ C    /
+//!  ↘    ↘  /
+//!   D -→ F
+//!
+//! The final execution result is 272.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use dagrs::{
+    connection::{in_channel::TypedInChannels, out_channel::TypedOutChannels},
+    node::typed_action::TypedAction,
+    Content, DefaultNode, EnvVar, Graph, Node, NodeTable, Output,
+};
+
+const BASE: &str = "base";
+
+struct Compute(usize);
+
+#[async_trait]
+impl TypedAction for Compute {
+    type I = usize;
+    type O = usize;
+
+    async fn run(
+        &self,
+        mut in_channels: TypedInChannels<Self::I>,
+        out_channels: TypedOutChannels<Self::O>,
+        env: Arc<EnvVar>,
+    ) -> Output {
+        let base = env.get::<usize>(BASE).unwrap();
+        let mut sum = self.0;
+
+        // Collect all input values from input channels
+        let inputs = in_channels
+            .map(|result| {
+                if let Ok(Some(value)) = result {
+                    *value
+                } else {
+                    0
+                }
+            })
+            .await;
+
+        // Calculate the sum
+        for input in inputs {
+            sum += input * base;
+        }
+
+        // Broadcast the result to all output channels
+        out_channels.broadcast(sum).await;
+
+        Output::Out(Some(Content::new(sum)))
+    }
+}
+
+fn main() {
+    env_logger::init();
+
+    let mut node_table = NodeTable::default();
+
+    let a = DefaultNode::with_action("Compute A".to_string(), Compute(1), &mut node_table);
+    let a_id = a.id();
+
+    let b = DefaultNode::with_action("Compute B".to_string(), Compute(2), &mut node_table);
+    let b_id = b.id();
+
+    let mut c = DefaultNode::new("Compute C".to_string(), &mut node_table);
+    c.set_action(Compute(4));
+    let c_id = c.id();
+
+    let mut d = DefaultNode::new("Compute D".to_string(), &mut node_table);
+    d.set_action(Compute(8));
+    let d_id = d.id();
+
+    let e = DefaultNode::with_action("Compute E".to_string(), Compute(16), &mut node_table);
+    let e_id = e.id();
+    let f = DefaultNode::with_action("Compute F".to_string(), Compute(32), &mut node_table);
+    let f_id = f.id();
+
+    let g = DefaultNode::with_action("Compute G".to_string(), Compute(64), &mut node_table);
+    let g_id = g.id();
+
+    let mut graph = Graph::new();
+    vec![a, b, c, d, e, f, g]
+        .into_iter()
+        .for_each(|node| graph.add_node(node));
+
+    graph.add_edge(a_id, vec![b_id, c_id, d_id]);
+    graph.add_edge(b_id, vec![e_id, g_id]);
+    graph.add_edge(c_id, vec![e_id, f_id]);
+    graph.add_edge(d_id, vec![f_id]);
+    graph.add_edge(e_id, vec![g_id]);
+    graph.add_edge(f_id, vec![g_id]);
+
+    let mut env = EnvVar::new(node_table);
+    env.set("base", 2usize);
+    graph.set_env(env);
+
+    match graph.start() {
+        Ok(_) => {
+            let res = graph
+                .get_results::<usize>()
+                .get(&g_id)
+                .unwrap()
+                .clone()
+                .unwrap();
+            // 验证执行结果
+            assert_eq!(*res, 272)
+        }
+        Err(e) => {
+            panic!("图执行失败: {:?}", e);
+        }
+    }
+}

--- a/src/connection/information_packet.rs
+++ b/src/connection/information_packet.rs
@@ -3,7 +3,7 @@ use std::{any::Any, sync::Arc};
 /// Container type to store task output.
 #[derive(Debug, Clone)]
 pub struct Content {
-    inner: Arc<dyn Any + Send + Sync>,
+    pub inner: Arc<dyn Any + Send + Sync>,
 }
 
 impl Content {

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -3,3 +3,4 @@ pub mod conditional_node;
 pub mod default_node;
 pub mod id_allocate;
 pub mod node;
+pub mod typed_action;

--- a/src/node/node.rs
+++ b/src/node/node.rs
@@ -44,6 +44,18 @@ pub trait Node: Send + Sync {
     fn loop_structure(&self) -> Option<Vec<Arc<Mutex<dyn Node>>>> {
         None
     }
+
+    /// Returns true if this node has TypedContent input.
+    /// By default, it returns false.
+    fn has_typed_input(&self) -> bool {
+        false
+    }
+
+    /// Returns true if this node has TypedContent output.
+    /// By default, it returns false.
+    fn has_typed_output(&self) -> bool {
+        false
+    }
 }
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy, Ord, PartialOrd)]

--- a/src/node/typed_action.rs
+++ b/src/node/typed_action.rs
@@ -1,0 +1,89 @@
+use std::{marker::PhantomData, sync::Arc};
+
+use async_trait::async_trait;
+
+use crate::{
+    connection::{in_channel::TypedInChannels, out_channel::TypedOutChannels},
+    Action, EnvVar, InChannels, OutChannels, Output,
+};
+
+/// A trait that provides typed channel operations
+///
+/// This trait allows actions to use typed input and output channels instead of raw channel types.
+/// Through generic parameters `I` and `O`, specific types can be specified for input and output channels,
+/// providing compile-time type checking.
+///
+/// # Type Parameters
+///
+/// * `I` - The type parameter for input channels, must satisfy `Send + Sync + 'static`
+/// * `O` - The type parameter for output channels, must satisfy `Send + Sync + 'static`
+/// When both `I` and `O` are set to `Content`, this trait degenerates to the base `Action` trait.
+#[async_trait]
+pub trait TypedAction: Send + Sync {
+    /// The type parameter for input channels
+    type I: Send + Sync + 'static;
+    /// The type parameter for output channels
+    type O: Send + Sync + 'static;
+
+    /// Converts raw input channels to typed input channels
+    ///
+    /// # Arguments
+    ///
+    /// * `in_channels` - The raw input channels
+    ///
+    /// # Returns
+    ///
+    /// Returns a typed input channel with the type specified by the associated type `I`
+    fn make_typed_in_channels(&self, in_channels: &InChannels) -> TypedInChannels<Self::I> {
+        TypedInChannels(in_channels.0.clone(), PhantomData::default())
+    }
+
+    /// Converts raw output channels to typed output channels
+    ///
+    /// # Arguments
+    ///
+    /// * `out_channels` - The raw output channels
+    ///
+    /// # Returns
+    ///
+    /// Returns a typed output channel with the type specified by the associated type `O`
+    fn make_typed_out_channels(&self, out_channels: &OutChannels) -> TypedOutChannels<Self::O> {
+        TypedOutChannels(out_channels.0.clone(), PhantomData::default())
+    }
+
+    /// The method that users need to implement to define their action logic
+    ///
+    /// This is the main method of the trait, used to execute the specific action logic.
+    /// It receives typed input and output channels, along with environment variables,
+    /// and returns the execution result.
+    ///
+    /// # Arguments
+    ///
+    /// * `in_channels` - The typed input channels
+    /// * `out_channels` - The typed output channels
+    /// * `env` - The environment variables
+    ///
+    /// # Returns
+    ///
+    /// Returns the result of the action execution
+    async fn run(
+        &self,
+        in_channels: TypedInChannels<Self::I>,
+        out_channels: TypedOutChannels<Self::O>,
+        env: Arc<EnvVar>,
+    ) -> Output;
+}
+
+#[async_trait]
+impl<T: TypedAction> Action for T {
+    async fn run(
+        &self,
+        in_channels: &mut InChannels,
+        out_channels: &mut OutChannels,
+        env: Arc<EnvVar>,
+    ) -> Output {
+        let in_channels = self.make_typed_in_channels(in_channels);
+        let out_channels = self.make_typed_out_channels(out_channels);
+        self.run(in_channels, out_channels, env).await
+    }
+}


### PR DESCRIPTION
# Add Typed Channel Communication

This PR introduces `TypedAction` and typed channels (`TypedInChannels` and `TypedOutChannels`) to provide fixed-type communication between nodes in the DAG. This enhancement ensures compile-time type checking for data flow between nodes.

The original design of adding typed channels directly to the graph structure faced challenges due to Rust's type system constraints. When using generic type parameters for channels, it becomes difficult to maintain type safety while keeping the graph structure flexible and dynamic. This is because:
1. The graph needs to handle nodes with different input/output types
2. Generic type parameters would need to be propagated through the entire graph structure
3. Type erasure would be necessary at some point, potentially compromising type safety

To address these challenges, we introduced `TypedAction` as a wrapper around the channel communication logic. This approach:
1. Encapsulates type information within the action implementation
2. Allows the graph to remain type-agnostic while maintaining type safety at the node level
3. Provides a clean interface for implementing type-safe data flow

## Example Implementation
The `examples\typed_action.rs` demonstrates this design by rewriting `examples\compute_dag.rs`:
```rust
struct Compute(usize);

#[async_trait]
impl TypedAction for Compute {
    type I = usize;
    type O = usize;

    async fn run(
        &self,
        mut in_channels: TypedInChannels<Self::I>,
        out_channels: TypedOutChannels<Self::O>,
        env: Arc<EnvVar>,
    ) -> Output {
        // Type-safe data processing
        let inputs = in_channels.map(|result| {
            if let Ok(Some(value)) = result {
                *value
            } else {
                0
            }
        }).await;

        // Process and broadcast results
        let sum = inputs.iter().sum();
        out_channels.broadcast(sum).await;
        
        Output::Out(Some(Content::new(sum)))
    }
}
```

## Related Issues
#105 #104 