### PR TITLE
Better IP management

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [".", "dagrs-derive"]
 
 [dependencies]
 dagrs-derive = { path = "dagrs-derive", optional = true, version = "0.4.3" }
-tokio = { version = "1.28", features = ["rt", "sync", "rt-multi-thread"] }
+tokio = { version = "1.28", features = ["rt", "sync", "rt-multi-thread", "time"] }
 log = "0.4"
 async-trait = "0.1.83"
 futures = "0.3.31"

--- a/examples/recv_any_example.rs
+++ b/examples/recv_any_example.rs
@@ -1,0 +1,187 @@
+//! # Example: recv_any_example
+//! Demonstrates how to use the `recv_any` method of `InChannels` to receive data from any available channel.
+//!
+//!
+//! # Output
+//! When running this example, you will see output similar to:
+//! ```
+//! Received message 'Hello from Sender' from node NodeId(1)
+//! Received message 'Hello from SlowSender' from node NodeId(2)
+//! ```
+//!
+//! The first message comes from the normal sender, and the second message comes from the slow sender
+//! after a 500ms delay.
+//!
+//! //! This example creates a graph with two senders and one receiver:
+//! - A normal sender that sends messages immediately
+//! - A slow sender that delays 500ms before sending messages
+//! - A receiver that uses `recv_any` to receive messages from either sender
+//!
+//! # Output
+//! When running this example, you will see output similar to:
+//! ```
+//! Received message 'Hello from Sender' from node NodeId(1)
+//! Received message 'Hello from SlowSender' from node NodeId(2)
+//! ```
+//!
+//! The first message comes from the normal sender, and the second message comes from the slow sender
+//! after a 500ms delay.
+
+use std::{sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use dagrs::{
+    connection::{in_channel::TypedInChannels, out_channel::TypedOutChannels},
+    node::typed_action::TypedAction,
+    DefaultNode, EnvVar, Graph, Node, NodeTable, Output,
+};
+use tokio::time::sleep;
+
+/// An action that sends a message to its output channel
+#[derive(Default)]
+pub struct SenderAction {
+    message: String,
+}
+
+impl SenderAction {
+    pub fn new(message: String) -> Self {
+        Self { message }
+    }
+}
+
+#[async_trait]
+impl TypedAction for SenderAction {
+    type I = ();
+    type O = String;
+
+    async fn run(
+        &self,
+        _: TypedInChannels<Self::I>,
+        out: TypedOutChannels<Self::O>,
+        _: Arc<EnvVar>,
+    ) -> Output {
+        // Send the message to all receivers
+        out.broadcast(self.message.clone()).await;
+        Output::Out(None)
+    }
+}
+
+/// An action that sends a message to its output channel after a delay
+#[derive(Default)]
+pub struct SlowSenderAction {
+    message: String,
+}
+
+impl SlowSenderAction {
+    pub fn new(message: String) -> Self {
+        Self { message }
+    }
+}
+
+#[async_trait]
+impl TypedAction for SlowSenderAction {
+    type I = ();
+    type O = String;
+
+    async fn run(
+        &self,
+        _: TypedInChannels<Self::I>,
+        out: TypedOutChannels<Self::O>,
+        _: Arc<EnvVar>,
+    ) -> Output {
+        // Wait for 500ms before sending
+        sleep(Duration::from_millis(500)).await;
+        // Send the message to all receivers
+        out.broadcast(self.message.clone()).await;
+        Output::Out(None)
+    }
+}
+
+/// An action that receives messages from any available channel
+#[derive(Default)]
+pub struct ReceiverAction;
+
+#[async_trait]
+impl TypedAction for ReceiverAction {
+    type I = String;
+    type O = ();
+
+    async fn run(
+        &self,
+        mut input: TypedInChannels<Self::I>,
+        _: TypedOutChannels<Self::O>,
+        _: Arc<EnvVar>,
+    ) -> Output {
+        // Receive from any available channel
+        match input.recv_any().await {
+            Ok((sender_id, content)) => {
+                let message = content.unwrap();
+                println!("Received message '{}' from node {:?}", message, sender_id);
+            }
+            Err(e) => {
+                eprintln!("Error receiving message: {:?}", e);
+            }
+        }
+
+        match input.recv_any().await {
+            Ok((sender_id, content)) => {
+                let message = content.unwrap();
+                println!("Received message '{}' from node {:?}", message, sender_id);
+            }
+            Err(e) => {
+                eprintln!("Error receiving message: {:?}", e);
+            }
+        }
+
+        Output::Out(None)
+    }
+}
+
+fn main() {
+    // Create a node table
+    let mut node_table = NodeTable::new();
+
+    // Create sender nodes
+    let sender1 = DefaultNode::with_action(
+        "Sender1".to_string(),
+        SenderAction::new("Hello from Sender".to_string()),
+        &mut node_table,
+    );
+    let sender2 = DefaultNode::with_action(
+        "Sender2".to_string(),
+        SlowSenderAction::new("Hello from SlowSender".to_string()),
+        &mut node_table,
+    );
+
+    // Create receiver node
+    let receiver = DefaultNode::with_action(
+        "Receiver".to_string(),
+        ReceiverAction::default(),
+        &mut node_table,
+    );
+
+    // Get node IDs before adding nodes to the graph
+    let sender1_id = sender1.id();
+    let sender2_id = sender2.id();
+    let receiver_id = receiver.id();
+
+    // Create a graph
+    let mut graph = Graph::new();
+
+    // Add nodes to the graph
+    graph.add_node(sender1);
+    graph.add_node(sender2);
+    graph.add_node(receiver);
+
+    // Add edges: both senders connect to the receiver
+    graph.add_edge(sender1_id, vec![receiver_id]);
+    graph.add_edge(sender2_id, vec![receiver_id]);
+
+    // Run the graph
+    match graph.start() {
+        Ok(_) => (),
+        Err(e) => {
+            eprintln!("Graph execution failed: {:?}", e);
+        }
+    }
+}

--- a/examples/typed_action.rs
+++ b/examples/typed_action.rs
@@ -116,7 +116,7 @@ fn main() {
             assert_eq!(*res, 272)
         }
         Err(e) => {
-            panic!("图执行失败: {:?}", e);
+            panic!("Graph execution failed: {:?}", e);
         }
     }
 }

--- a/src/connection/out_channel.rs
+++ b/src/connection/out_channel.rs
@@ -69,6 +69,11 @@ impl OutChannels {
     pub(crate) fn insert(&mut self, node_id: NodeId, channel: Arc<Mutex<OutChannel>>) {
         self.0.insert(node_id, channel);
     }
+
+    /// Returns a list of all available receiver node IDs.
+    pub fn get_receiver_ids(&self) -> Vec<NodeId> {
+        self.0.keys().copied().collect()
+    }
 }
 
 /// # Output Channel
@@ -179,10 +184,6 @@ impl<T: Send + Sync + 'static> TypedOutChannels<T> {
         }
     }
 
-    pub(crate) fn close_all(&mut self) {
-        self.0.clear();
-    }
-
     fn get(&self, id: &NodeId) -> Option<Arc<Mutex<OutChannel>>> {
         match self.0.get(id) {
             Some(c) => Some(c.clone()),
@@ -190,7 +191,8 @@ impl<T: Send + Sync + 'static> TypedOutChannels<T> {
         }
     }
 
-    pub(crate) fn insert(&mut self, node_id: NodeId, channel: Arc<Mutex<OutChannel>>) {
-        self.0.insert(node_id, channel);
+    /// Returns a list of all available receiver node IDs.
+    pub fn get_receiver_ids(&self) -> Vec<NodeId> {
+        self.0.keys().copied().collect()
     }
 }


### PR DESCRIPTION
# Better IP management

This PR introduces several improvements to the information packet (IP) management in Dagrs:

## New Features

### InChannels
Added `recv_any` method to receive data from any available channel without specifying the sender's ID, which returns a tuple of `(sender_id, content)` to identify the message source.

### OutChannels
Added `get_receiver_ids` method to query available receiver nodes.

## Example
 `recv_any_example.rs` demonstrates how to use the `recv_any` method of `InChannels` to receive data from any available channel.

This example creates a graph with two senders and one receiver:
- A normal sender that sends messages immediately
- A slow sender that delays 500ms before sending messages
- A receiver that uses `recv_any` to receive messages from either sender

```
/// An action that sends a message to its output channel
#[derive(Default)]
pub struct SenderAction {
    message: String,
}

impl SenderAction {
    pub fn new(message: String) -> Self {
        Self { message }
    }
}

#[async_trait]
impl TypedAction for SenderAction {
    type I = ();
    type O = String;

    async fn run(
        &self,
        _: TypedInChannels<Self::I>,
        out: TypedOutChannels<Self::O>,
        _: Arc<EnvVar>,
    ) -> Output {
        // Send the message to all receivers
        out.broadcast(self.message.clone()).await;
        Output::Out(None)
    }
}

/// An action that sends a message to its output channel after a delay
#[derive(Default)]
pub struct SlowSenderAction {
    message: String,
}

impl SlowSenderAction {
    pub fn new(message: String) -> Self {
        Self { message }
    }
}

#[async_trait]
impl TypedAction for SlowSenderAction {
    type I = ();
    type O = String;

    async fn run(
        &self,
        _: TypedInChannels<Self::I>,
        out: TypedOutChannels<Self::O>,
        _: Arc<EnvVar>,
    ) -> Output {
        // Wait for 500ms before sending
        sleep(Duration::from_millis(500)).await;
        // Send the message to all receivers
        out.broadcast(self.message.clone()).await;
        Output::Out(None)
    }
}
```

So when the receiver calls the "recv_any" method, it will always receive messages from the normal sender, or to be more precise, most of the time. And the second time the receiver calls the "recv_any" method, it will receive messages from the slow sender.

## Related Issue
#106 #104 